### PR TITLE
Правит div -> h1

### DIFF
--- a/src/includes/item/title.njk
+++ b/src/includes/item/title.njk
@@ -1,8 +1,9 @@
 {% macro field(sort, name) %}
-    <div class="item__name">
+    <h1 class="item__name">
         {% if sort %}
             <span class="item__desc">Сорт:</span>
         {% endif %}
-        {{ name }}</div>
+        {{ name }}
+    </h1>
 {% endmacro %}
 


### PR DESCRIPTION
Немножко лечит диватоз

1. На странице должен быть `h1` заголовок. 
2. Если на странице есть заголовки меньшего уровня, `h1` обязан быть.