### PR TITLE
Dark theme select styles

### DIFF
--- a/src/includes/settings/settingsItem.njk
+++ b/src/includes/settings/settingsItem.njk
@@ -4,7 +4,7 @@
             {{ name }}:
             <select id={{ id }} class="settingsItem__select">
                 {%- for item in list -%}
-                    <option value={{ item.value }}>{{ languages[page.lang][id][item.value] }}</option>
+                    <option value={{ item.value }} class="settingsItem__selectOption">{{ languages[page.lang][id][item.value] }}</option>
                 {%- endfor -%}
             </select>
         </label>

--- a/src/styles/colors.css
+++ b/src/styles/colors.css
@@ -18,6 +18,7 @@
     --color-footer-boder: #c6c6c6;
 
     --color-author-icon-background: transparent;
+    --color-focus: black;
 }
 
 html[data-theme='dark'] {
@@ -36,4 +37,5 @@ html[data-theme='dark'] {
 
     --color-footer-boder: transparent;
     --color-author-icon-background: white;
+    --color-focus: white;
 }

--- a/src/styles/components/settings/settings.css
+++ b/src/styles/components/settings/settings.css
@@ -18,20 +18,33 @@
     font-weight: bold;
 }
 
-/*TODO: Add a11y back! */
 .settingsItem__select {
     position: relative;
     font-size: 1.2em;
+    text-align: right;
     border: none;
+    border-radius: 4px;
     background-color: inherit;
-    background-image: url("data:image/svg+xml,%3Csvg role='img' aria-hidden='true' width='28' height='28' xmlns='http://www.w3.org/2000/svg' fill-rule='evenodd' viewBox='0 0 847 847'%3E%3Cpath d='M242 298l181 185 182-185c24-25 65 16 40 41L440 550c-9 9-24 9-32 0L201 339c-24-25 17-66 41-41z'/%3E%3C/svg%3E");
+    background-image: url("data:image/svg+xml,%3Csvg fill='black' aria-hidden='true' width='28' height='28' xmlns='http://www.w3.org/2000/svg' fill-rule='evenodd' viewBox='0 0 847 847'%3E%3Cpath d='M242 298l181 185 182-185c24-25 65 16 40 41L440 550c-9 9-24 9-32 0L201 339c-24-25 17-66 41-41z'/%3E%3C/svg%3E");
     background-size: 16px;
     background-position: right 5px;
     background-repeat: no-repeat;
     appearance: none;
-    padding: 0 17px 0 0;
-    direction: rtl;
+    padding: 0 20px 0 0;
     color: var(--color-text);
     outline: none;
+}
+
+.settingsItem__select:focus-visible {
+  outline: 2px solid var(--color-focus);
+}
+
+/* Seems there is no other way to change colors inside bg-image */
+:root[data-theme='dark'] .settingsItem__select {
+    background-image: url("data:image/svg+xml,%3Csvg fill='white' aria-hidden='true' width='28' height='28' xmlns='http://www.w3.org/2000/svg' fill-rule='evenodd' viewBox='0 0 847 847'%3E%3Cpath d='M242 298l181 185 182-185c24-25 65 16 40 41L440 550c-9 9-24 9-32 0L201 339c-24-25 17-66 41-41z'/%3E%3C/svg%3E");
+}
+
+.settingsItem__selectOption {
+    background-color: var(--color-menu-tool);
 }
 


### PR DESCRIPTION
Maybe focus styles were removed on purpose, because focus-visible seems to not give a shit for selects even when mouse pressed, but it's worse not to have a focus indicator